### PR TITLE
Check the last line of output from go version

### DIFF
--- a/autoload/gopher/init.vim
+++ b/autoload/gopher/init.vim
@@ -20,9 +20,14 @@ fun! gopher#init#version() abort
   endif
 
   if l:msg isnot# ''
+    echohl Error
     for l:l in split(l:msg, "\n")
-      echoerr l:l
+      echom l:l
     endfor
+    echohl None
+
+    " Make sure people see any warnings.
+    sleep 2
   endif
 endfun
 

--- a/autoload/gopher/init.vim
+++ b/autoload/gopher/init.vim
@@ -12,29 +12,35 @@ fun! gopher#init#version() abort
   endif
 
   " Ensure people have Go installed correctly.
-  let l:v = split(system('go version'), '\n')[-1]
-  if v:shell_error > 0 || !gopher#init#version_check(l:v)
+  let l:v = system('go version')
+  if v:shell_error > 0
     let l:msg = "Go doesn't seem installed correctly? 'go version' failed with:\n" . l:v
-  " Ensure sure people have Go 1.11.
-  elseif l:v[:15] isnot# 'go version devel' && str2nr(l:v[15:], 10) < 11
-    let l:msg = "gopher.vim needs Go 1.11 or newer; reported version was:\n" . l:v
+  else
+      let l:msg = gopher#init#version_check(l:v)
   endif
 
   if l:msg isnot# ''
-    echohl Error
     for l:l in split(l:msg, "\n")
-      echom l:l
+      echoerr l:l
     endfor
-    echohl None
-
-    " Make sure people see any warnings.
-    sleep 2
   endif
 endfun
 
 " Check if the 'go version' output is a version we support.
 fun! gopher#init#version_check(v) abort
-  return a:v =~# '^go version \(devel\|go1\.\d\d\(\.\d\d\?\)\?\) .\+/.\+$'
+  for l:line in split(a:v, '\n')
+    if l:line !~# '^go version \(devel\|go1\.\d\d\(\.\d\d\?\)\?\) .\+/.\+$'
+      continue
+    endif
+
+    if l:line[:15] isnot# 'go version devel' && str2nr(l:line[15:], 10) < 11
+      return "gopher.vim needs Go 1.11 or newer; reported version was:\n" . l:line
+    endif
+
+    return ''
+  endfor
+
+  return "gopher.vim needs Go 1.11 or newer; reported version was:\n" . a:v
 endfun
 
 let s:root    = expand('<sfile>:p:h:h:h') " Root dir of this plugin.

--- a/autoload/gopher/init.vim
+++ b/autoload/gopher/init.vim
@@ -12,7 +12,7 @@ fun! gopher#init#version() abort
   endif
 
   " Ensure people have Go installed correctly.
-  let l:v = system('go version')
+  let l:v = split(system('go version'), '\n')[-1]
   if v:shell_error > 0 || !gopher#init#version_check(l:v)
     let l:msg = "Go doesn't seem installed correctly? 'go version' failed with:\n" . l:v
   " Ensure sure people have Go 1.11.

--- a/autoload/gopher/init_test.vim
+++ b/autoload/gopher/init_test.vim
@@ -5,9 +5,11 @@ fun! Test_version_check() abort
   let l:tests = [ 'go version go1.11.5 linux/amd64',
                 \ 'go version go1.12 linux/amd64',
                 \ 'go version go1.11.13 linux/amd64',
-                \ 'go version devel +e37a1b1ca6 Tue Aug 6 23:05:55 2019 +0000 darwin/amd64']
+                \ 'go version devel +e37a1b1ca6 Tue Aug 6 23:05:55 2019 +0000 darwin/amd64',
+                \ 'Some wrapper script outputs stuff before\ngo version go1.11.13 linux/amd64',
+                \ 'go version go1.11.13 linux/amd64\nSome wrapper script outputs stuff after']
   for l:tt in l:tests
-    if !gopher#init#version_check(l:tt)
+    if gopher#init#version_check(l:tt) != ''
       call Errorf('version check failed for %s', l:tt)
     endif
   endfor

--- a/autoload/gopher/init_test.vim
+++ b/autoload/gopher/init_test.vim
@@ -6,11 +6,12 @@ fun! Test_version_check() abort
                 \ 'go version go1.12 linux/amd64',
                 \ 'go version go1.11.13 linux/amd64',
                 \ 'go version devel +e37a1b1ca6 Tue Aug 6 23:05:55 2019 +0000 darwin/amd64',
-                \ 'Some wrapper script outputs stuff before\ngo version go1.11.13 linux/amd64',
-                \ 'go version go1.11.13 linux/amd64\nSome wrapper script outputs stuff after']
+                \ "Some wrapper script outputs stuff before\ngo version go1.11.13 linux/amd64",
+                \ "go version go1.11.13 linux/amd64\nSome wrapper script outputs stuff after"]
   for l:tt in l:tests
-    if gopher#init#version_check(l:tt) != ''
-      call Errorf('version check failed for %s', l:tt)
+    let l:out = gopher#init#version_check(l:tt)
+    if l:out isnot ''
+      call Errorf('version check failed for %s: "%s"', l:tt, l:out)
     endif
   endfor
 endfun

--- a/autoload/gopher/init_test.vim
+++ b/autoload/gopher/init_test.vim
@@ -10,7 +10,7 @@ fun! Test_version_check() abort
                 \ "go version go1.11.13 linux/amd64\nSome wrapper script outputs stuff after"]
   for l:tt in l:tests
     let l:out = gopher#init#version_check(l:tt)
-    if l:out isnot ''
+    if l:out isnot# ''
       call Errorf('version check failed for %s: "%s"', l:tt, l:out)
     endif
   endfor

--- a/fail
+++ b/fail
@@ -1,2 +1,0 @@
-
-	if SMTP == "stdout" && Print {

--- a/fail
+++ b/fail
@@ -1,0 +1,2 @@
+
+	if SMTP == "stdout" && Print {


### PR DESCRIPTION
This makes `gopher.vim` work in my particular environment, where `go` is a shell wrapper and is outputting extra text before printing the version. Instead of expecting the entirety of `go version` output to contain the version information, this instead uses only the last line.

Let me know if this is something you would consider to include in the plugin.