### PR TITLE
Better capture for slightly changed 1.14 test -v output.

### DIFF
--- a/compiler/gotest.vim
+++ b/compiler/gotest.vim
@@ -73,6 +73,10 @@ let &l:errorformat .= ',%A' . s:indent . "%#%\\t%\\+%f:%l: "
 " want when writing a newline into their test output.
 let &l:errorformat .= ',%G' . s:indent . "%#%\\t%\\{2}%m"
 " }}}1
+ 
+" work with 1.14 'go test -v'
+let &l:errorformat .= ',%A' . s:indent . "%\\+%[%^:]%\\+: %f:%l: %m"
+let &l:errorformat .= ',%A' . s:indent . "%\\+%[%^:]%\\+: %f:%l: "
 
 " Go 1.11 test output {{{1
 " Match test output lines similarly to Go 1.10 test output lines, but they


### PR DESCRIPTION
I stole this from vim-go after upgrading to Go 1.14 and seeing that test -v capture was off. It looks like 1.14 changed the format for test -v slightly.