### PR TITLE
Make compilers compatible with dispatch

### DIFF
--- a/compiler/go.vim
+++ b/compiler/go.vim
@@ -5,6 +5,7 @@ let g:current_compiler = 'go'
 let s:save_cpo = &cpoptions
 set cpoptions-=C
 
+" CompilerSet makeprg=go
 let &l:makeprg = printf('go install %s %s',
       \ gopher#system#join(get(g:, 'gopher_build_flags', [])),
       \ get(g:, 'gopher_install_package', ''))

--- a/compiler/golint.vim
+++ b/compiler/golint.vim
@@ -5,6 +5,7 @@ let g:current_compiler = 'golint'
 let s:save_cpo = &cpoptions
 set cpoptions-=C
 
+" CompilerSet makeprg=golangci-lint
 let &l:makeprg = 'golangci-lint run --out-format tab'
 if len(get(g:, 'gopher_build_tags', [])) > 0
   let &l:makeprg .= printf(' --build-tags "%s"', join(g:gopher_build_tags, ' '))

--- a/compiler/gotest.vim
+++ b/compiler/gotest.vim
@@ -73,6 +73,10 @@ let &l:errorformat .= ',%A' . s:indent . "%#%\\t%\\+%f:%l: "
 " want when writing a newline into their test output.
 let &l:errorformat .= ',%G' . s:indent . "%#%\\t%\\{2}%m"
 " }}}1
+ 
+" work with 1.14 'go test -v'
+let &l:errorformat .= ',%A' . s:indent . "%\\+%[%^:]%\\+: %f:%l: %m"
+let &l:errorformat .= ',%A' . s:indent . "%\\+%[%^:]%\\+: %f:%l: "
 
 " Go 1.11 test output {{{1
 " Match test output lines similarly to Go 1.10 test output lines, but they

--- a/compiler/gotest.vim
+++ b/compiler/gotest.vim
@@ -7,6 +7,7 @@ let g:current_compiler = 'gotest'
 let s:save_cpo = &cpoptions
 set cpoptions-=C
 
+" CompilerSet makeprg=go\ test
 let &l:makeprg = 'go test ' . gopher#system#join(get(g:, 'gopher_build_flags', []))
 
 let s:goroot = system('go env s:goroot')[:-2]


### PR DESCRIPTION
Make the compilers compatible with vim-dispatch. vim-dispatch parses every compiler and looks for strings roughly matching: CompilerSet makeprg=<program>
It mentions in its help that simply making a comment with such a string will also work. That's what I've done here.