### PR TITLE
Make the compilers compatible with vim-dispatch.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -105,6 +105,8 @@ various plugins.
   [ALE](https://github.com/dense-analysis/ale).
 
 - [vim-makejob](https://git.danielmoch.com/vim-makejob) – Async `:make`.
+  Alternatives:
+  [vim-dispatch](https://github.com/tpope/vim-dispatch)
 
 - [switchy.vim](https://github.com/arp242/switchy.vim) – Switch to `_test.go`
   files. Alternatives:

--- a/compiler/go.vim
+++ b/compiler/go.vim
@@ -5,6 +5,7 @@ let g:current_compiler = 'go'
 let s:save_cpo = &cpoptions
 set cpoptions-=C
 
+" CompilerSet makeprg=go
 let &l:makeprg = printf('go install %s %s',
       \ gopher#system#join(get(g:, 'gopher_build_flags', [])),
       \ get(g:, 'gopher_install_package', ''))

--- a/compiler/golint.vim
+++ b/compiler/golint.vim
@@ -5,6 +5,7 @@ let g:current_compiler = 'golint'
 let s:save_cpo = &cpoptions
 set cpoptions-=C
 
+" CompilerSet makeprg=golangci-lint
 let &l:makeprg = 'golangci-lint run --out-format tab'
 if len(get(g:, 'gopher_build_tags', [])) > 0
   let &l:makeprg .= printf(' --build-tags "%s"', join(g:gopher_build_tags, ' '))

--- a/compiler/gotest.vim
+++ b/compiler/gotest.vim
@@ -7,6 +7,7 @@ let g:current_compiler = 'gotest'
 let s:save_cpo = &cpoptions
 set cpoptions-=C
 
+" CompilerSet makeprg=go\ test
 let &l:makeprg = 'go test ' . gopher#system#join(get(g:, 'gopher_build_flags', []))
 
 let s:goroot = system('go env s:goroot')[:-2]

--- a/doc/gopher.txt
+++ b/doc/gopher.txt
@@ -197,6 +197,11 @@ go~
                 gotest                  `go test`
                 golint                  `golangci-lint`
 
+        The compilers are compatible with vim-dispatch, but none of the
+        settings below will take effect (so you'll need to use
+        `:Dispatch go build ./cmd/pkg`; the package name won't be added
+        automatically).
+
                                                     *g:gopher_install_package*
         Can be set to a package name to install with |:make|; default is to
         use the current directory. This is especially useful if the main


### PR DESCRIPTION
vim-dispatch parses every compiler and looks for strings
roughly matching: CompilerSet makeprg=<program>
It mentions in its help that simply making a comment
with such a string will also work. That's what I've done here.