### PR TITLE
Make clear_hi works when the <afile> is not provided

### DIFF
--- a/autoload/gopher/coverage.vim
+++ b/autoload/gopher/coverage.vim
@@ -94,7 +94,7 @@ endfun
 fun! gopher#coverage#stop() abort
   let s:visible = 0
   let s:coverage = {}
-  silent! au! gopher-coverage
+  silent! au! gopher.vim-coverage
 
   for l:w in gopher#win#list()
     call gopher#coverage#clear_hi(l:w)

--- a/autoload/gopher/coverage.vim
+++ b/autoload/gopher/coverage.vim
@@ -79,7 +79,7 @@ fun! gopher#coverage#clear_hi(winid) abort
 
   " The current buffer is different from the buffer being unloaded; this
   " probably means we closed a tab, and we don't need to do anything.
-  if expand('<afile>') isnot# expand('%')
+  if !!expand('<afile>') && expand('<afile>') isnot# expand('%')
     return
   endif
 

--- a/autoload/gopher/coverage_test.vim
+++ b/autoload/gopher/coverage_test.vim
@@ -37,6 +37,7 @@ fun! Test_highlight() abort
         \ {'group': 'goCoverageCovered', 'priority': 10, 'pos1': [8]},
         \ {'group': 'goCoverageCovered', 'priority': 10, 'pos1': [9]},
         \ {'group': 'goCoverageCovered', 'priority': 10, 'pos1': [9, 1, 1]}]
+
   " Remove id as it's not stable.
   let l:got = map(getmatches(), {i, v -> remove(l:v, 'id') is '' ? {} : l:v })
 


### PR DESCRIPTION
```
<afile>    When executing autocommands, is replaced with the file name
     of the buffer being manipulated, or the file for a read or
     write.  *E495*
```

Executing autocommands, `<afile>` will be replaced with the file name.
Calling `:GoCoverage clear`, `<afile>` is empty.

for: #48
