### PR TITLE
Fix crashing when chdir function doesn't exist

### DIFF
--- a/autoload/gopher/go.vim
+++ b/autoload/gopher/go.vim
@@ -27,7 +27,7 @@ fun! gopher#go#module() abort
   let l:wd = getcwd()
 
   try
-    call chdir(expand('%:h'))
+    call gopher#system#cd(expand('%:h'))
     let [l:out, l:err] = gopher#system#run(['go', 'list', '-m', '-f',
           \ "{{.Path}}\x01{{.Dir}}"])
     if l:err
@@ -35,7 +35,7 @@ fun! gopher#go#module() abort
     endif
     return split(l:out, "\x01")
   finally
-    call chdir(l:wd)
+    call gopher#system#cd(l:wd)
   endtry
 endfun
 

--- a/autoload/gopher/system.vim
+++ b/autoload/gopher/system.vim
@@ -499,5 +499,14 @@ fun! gopher#system#closest(name) abort
   endwhile
 endfun
 
+" Change the current directory to path.
+fun! gophor#system#cd(path) abort
+  if exists('*chdir')
+    call chdir(a:path)
+  else
+    silent execute 'lcd' fnameescape(a:path)
+  endif
+endfun
+
 
 call s:init()  " At end so entire file is parsed.

--- a/autoload/gopher/system.vim
+++ b/autoload/gopher/system.vim
@@ -500,7 +500,7 @@ fun! gopher#system#closest(name) abort
 endfun
 
 " Change the current directory to path.
-fun! gophor#system#cd(path) abort
+fun! gopher#system#cd(path) abort
   if exists('*chdir')
     call chdir(a:path)
   else


### PR DESCRIPTION
Fixes #50.

Some NeoVim environment seems has no `chdir()` function. If doesn't, use `lcd` ex-command instead.