### PR TITLE
respect :compiler!

### DIFF
--- a/compiler/go.vim
+++ b/compiler/go.vim
@@ -12,6 +12,7 @@ let &l:makeprg = gopher#str#fold_space(printf('go %s %s %s %s',
       \ gopher#bufsetting('gopher_build_tags', -1) is# -1 ? '' :
       \     gopher#system#join(['-tags', join(gopher#bufsetting('gopher_build_tags', []), ',')]),
       \ gopher#bufsetting('gopher_build_package', '')))
+exe 'CompilerSet makeprg='..escape(&l:makeprg, ' \|"')
 
 setl errorformat =%-G#\ %.%#                   " Ignore lines beginning with '#' ('# command-line-arguments' line sometimes appears?)
 setl errorformat+=%-G%.%#panic:\ %m            " Ignore lines containing 'panic: message'
@@ -20,6 +21,7 @@ setl errorformat+=%A%f:%l:%c:\ %m              " Start of multiline unspecified 
 setl errorformat+=%A%f:%l:\ %m                 " Start of multiline unspecified string is 'filename:linenumber:'
 setl errorformat+=%C%*\\s%m                    " Continuation of multiline error message is indented
 setl errorformat+=%-G%.%#                      " All lines not matching any of the above patterns are ignored
+exe 'CompilerSet errorformat='..escape(&l:errorformat, ' \|"')
 
 let &cpoptions = s:save_cpo
 unlet s:save_cpo

--- a/compiler/golint.vim
+++ b/compiler/golint.vim
@@ -11,6 +11,7 @@ let &l:makeprg = 'staticcheck ./...'
 if len(get(g:, 'gopher_build_tags', [])) > 0
   let &l:makeprg .= printf(' --build-tags "%s"', join(gopher#bufsetting('gopher_build_tags', []) ' '))
 endif
+exe 'CompilerSet makeprg='..escape(&l:makeprg, ' \|"')
 
 " golangci-lint:
 "   benchmark_test.go:34:2   deadcode  `valFormT2` is unused
@@ -23,6 +24,7 @@ endif
 "   # zgo.at/goatcounter
 "   ./hit.go:38:2: struct field tag `db: "id" json:"-"` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
 let &l:errorformat = '%-G# %.%#,%f:%l:%c:\\? %m'
+exe 'CompilerSet errorformat='..escape(&l:errorformat, ' \|"')
 
 let &cpoptions = s:save_cpo
 unlet s:save_cpo

--- a/compiler/gotest.vim
+++ b/compiler/gotest.vim
@@ -10,6 +10,7 @@ set cpoptions-=C
 " CompilerSet makeprg=go\ test
 let &l:makeprg = gopher#str#fold_space(printf('go test %s',
       \ gopher#system#join(gopher#bufsetting('gopher_build_flags', []))))
+exe 'CompilerSet makeprg='..escape(&l:makeprg, ' \|"')
 
 let s:goroot = system('go env s:goroot')[:-2]
 
@@ -180,6 +181,7 @@ let &l:errorformat .= ",%G%\\t%m"
 let &l:errorformat .= ',%-C%.%#'
 " Match and ignore everything else not in a multi-line message:
 let &l:errorformat .= ',%-G%.%#'
+exe 'CompilerSet errorformat='..escape(&l:errorformat, ' \|"')
 
 """ vim-go end """
 


### PR DESCRIPTION
otherwise :compiler does not respect global settings; setting &l:makeprg is fine though, see discussion at https://github.com/vim/vim/pull/18686